### PR TITLE
docs: Blueprint:renamedFiles

### DIFF
--- a/lib/blueprint.js
+++ b/lib/blueprint.js
@@ -1331,8 +1331,15 @@ Blueprint.list = function(options) {
 };
 
 /**
+  Files that are renamed when installed into the target directory.
+  This allows including files in the blueprint that would have an effect
+  on another process, such as a file named `.gitignore`.
+
+  The keys are the filenames used in the files folder.
+  The values are the filenames used in the target directory.
+
   @static
-  @property renameFiles
+  @property renamedFiles
 */
 Blueprint.renamedFiles = {
   'gitignore': '.gitignore'


### PR DESCRIPTION
Ports the docs change from https://github.com/ember-cli/ember-cli/pull/6479
to blprnt.