### PR TITLE
CI: Enable automatic NPM deployment for tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,12 @@ install:
 
 script:
   - npm run test
+
+deploy:
+  provider: npm
+  email: stefan.penner+ember-cli@gmail.com
+  api_key:
+    secure: P8rw+xVuDSHQOH1dB4Rf5aTh5uqZFZ6Ioht3MmYfxlnVjW0xG6F4gQWsd8P7baSV++Fybm5WYPjCsWGA3pB3EZFD05zTT/7BQ8AIsPYU7rBmNbbtaTibCcj0qhJJtxRhmbDTzzvRfcE2ETyOuT42ZVczTvOPBxCtyb8kJyentCg=
+  on:
+    tags: true
+    repo: ember-cli/blprnt


### PR DESCRIPTION
After merging this you no longer have to `npm publish` manually. TravisCI will test all pushed tags and deploy automatically after all tests passed.

`npm owner add ember-cli` is still needed, because I didn't have the NPM owner bit to do it myself.

/cc @nathanhammond @stefanpenner @rwjblue