### PR TITLE
fix test scripts for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "A tool for describing and generating files and directory structures",
   "main": "index.js",
   "scripts": {
-    "test": "mocha 'tests/**/*-test.js'",
-    "test:debug": "mocha debug 'tests/**/*-test.js'"
+    "test": "mocha tests/**/*-test.js",
+    "test:debug": "mocha debug tests/**/*-test.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes tests startup on windows.

Before this change I had the following output:
```
PS C:\Users\ro0gr\workspace\blprnt> npm t

> blprnt@0.0.0 test C:\Users\ro0gr\workspace\blprnt
> mocha 'tests/**/*-test.js'

Warning: Could not find any test files matching pattern: 'tests/**/*-test.js'
No test files found
npm ERR! Test failed.  See above for more details.
```